### PR TITLE
Fix json decode handling

### DIFF
--- a/src/Concerns/WithState.php
+++ b/src/Concerns/WithState.php
@@ -45,8 +45,12 @@ trait WithState
     {
         $decoder = (new JsonDecoder())->fromBayes($this);
 
-        /** @var array<string, mixed> $decoded_content  */
-        $decoded_content = json_decode($content, true);
+        try {
+            /** @var array<string, mixed> $decoded_content */
+            $decoded_content = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new JsonCorruptedException(previous: $e);
+        }
 
         $decoder->decode($decoded_content);
 

--- a/tests/Unit/BayesTest.php
+++ b/tests/Unit/BayesTest.php
@@ -109,3 +109,10 @@ it('resets state correctly', function (): void {
         ->and($state['vocabulary'])->toBeEmpty()
         ->and($state['categoriesState'])->toBeEmpty();
 });
+
+it('throws JsonCorruptedException on malformed JSON', function (): void {
+    $bayes = new Bayes(new DefaultTokenizer());
+
+    expect(fn (): Bayes => $bayes->import('{invalid json'))
+        ->toThrow(JsonCorruptedException::class);
+});


### PR DESCRIPTION
## Summary
- catch `json_decode` failures in `import`
- test malformed JSON throws `JsonCorruptedException`

## Testing
- `composer test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68404ee05d04832ba0b641ad2fd8c182